### PR TITLE
Fixes #8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.1"
+  - "8.9"
 
 script:
   - npm run version

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "telnet",
     "rxjs"
   ],
+  "engines": {
+    "node": "8.9.x"
+  },
   "main": "dist/telnet.js",
   "types": "dist/telnet.d.ts",
   "scripts": {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -41,7 +41,7 @@ export class Connection extends ReplaySubject<Event> {
      */
     get data(): Observable<string> {
         return this.filter((event: Event) => event instanceof Event.Data)
-            .map((event: Event.Data) => event.data);
+            .map((event) => (event as Event.Data).data);
     }
 
     /**
@@ -49,7 +49,7 @@ export class Connection extends ReplaySubject<Event> {
      */
     get commands(): Observable<number[]> {
         return this.filter((event: Event) => event instanceof Event.Command)
-            .map((event: Event.Command) => event.command);
+            .map((event) => (event as Event.Command).command);
     }
 
     /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -176,8 +176,12 @@ export class Connection extends ReplaySubject<Event> {
                 }
             }
         } else {
-            telnetCommand.push(data[position]++);
-            telnetCommand.push(data[position]++);
+            if (position < data.length) {
+                telnetCommand.push(data[position++]);
+            }
+            if (position < data.length) {
+                telnetCommand.push(data[position++]);
+            }
         }
         this.next(new Event.Command(telnetCommand));
 
@@ -240,12 +244,4 @@ export namespace Connection {
         public static Connected: 'CONNECTED' = 'CONNECTED';
         public static Connecting: 'CONNECTING' = 'CONNECTING';
     }
-    /*
-    export enum State {
-        Disconnected = 'DISCONNECTED',
-        Disconnecting = 'DISCONNECTING',
-        Connecting = 'CONNECTING',
-        Connected = 'CONNECTED',
-    }
-    */
 }


### PR DESCRIPTION
In `connection.ts`, the data cursor was not being incremented properly in the
case of a non-SB telnet command.  Instead, it was incrementing the command
data itself (e.g., `WILL TERMINAL_SPEED` became `WONT REMOTE_FLOW_CONTROL`).

This changes fixes it and adds some buffer protection.